### PR TITLE
ci(release): add release-check and make release workflow publish only

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,68 @@
+name: Release Check
+
+on:
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  release-check:
+    name: Validate Release Pipeline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags
+        run: git fetch --tags --force
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Resolve next release version
+        id: version
+        run: |
+          set -euo pipefail
+          raw_version="$(git cliff --config cliff.toml --bumped-version --unreleased | tr -d '\r\n')"
+          version="${raw_version#v}"
+          if [ -z "$version" ]; then
+            echo "Failed to resolve next version with git-cliff."
+            exit 1
+          fi
+
+          tag="v${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "archive_name=ignition-workflows-${version}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          git cliff \
+            --config cliff.toml \
+            --unreleased \
+            --tag "${{ steps.version.outputs.tag }}" \
+            --strip header \
+            > dist/release-notes.md
+          test -s dist/release-notes.md
+
+      - name: Build release artifact
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          (
+            cd projects/workflows
+            zip -r "../../dist/${{ steps.version.outputs.archive_name }}" .
+          )
+          test -f "dist/${{ steps.version.outputs.archive_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   release:
     name: Build and Publish Release
-    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     concurrency:
       group: release-${{ github.ref }}
@@ -72,38 +71,6 @@ jobs:
             --tag "${{ steps.version.outputs.tag }}" \
             --strip header \
             > dist/release-notes.md
-
-      - name: Update CHANGELOG.md
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          if [ -f CHANGELOG.md ]; then
-            git cliff \
-              --config cliff.toml \
-              --unreleased \
-              --tag "${{ steps.version.outputs.tag }}" \
-              --prepend CHANGELOG.md
-          else
-            git cliff \
-              --config cliff.toml \
-              --unreleased \
-              --tag "${{ steps.version.outputs.tag }}" \
-              -o CHANGELOG.md
-          fi
-
-      - name: Commit and push CHANGELOG.md
-        if: steps.version.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          git add CHANGELOG.md
-          if git diff --cached --quiet -- CHANGELOG.md; then
-            echo "No changelog changes to commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore(release): prepare for ${{ steps.version.outputs.tag }} [skip ci]"
-          git push origin "HEAD:${{ github.ref_name }}"
 
       - name: Build release artifact
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
This is to avoid failures when the branch has been merged